### PR TITLE
Add update for 2026-06-14

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
       <ul id="updates">
         <!-- POSTS:START -->
         <!-- SLOT:2026-06-15 -->
-        <!-- SLOT:2026-06-14 -->
+        <li><span class="date">2026-06-14</span><a href="/posts/2026-06-14.html">New role at Verdant Cipher</a></li>
         <!-- SLOT:2026-06-13 -->
         <!-- SLOT:2026-06-12 -->
         <li><span class="date">2026-06-11</span><a href="/posts/2026-06-11.html">Now: Observability work</a></li>

--- a/posts/2026-06-14.html
+++ b/posts/2026-06-14.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>New role at Verdant Cipher &middot; Omas Abdullah</title>
+  <meta name="description" content="Now a Staff Telemetry Engineer at Verdant Cipher.">
+  <link rel="canonical" href="https://omasabdullah.github.io/posts/2026-06-14.html">
+  <meta name="robots" content="index, follow">
+  <link rel="stylesheet" href="/style.css">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Omas Abdullah",
+    "url": "https://omasabdullah.github.io/posts/2026-06-14.html",
+    "jobTitle": "Staff Telemetry Engineer",
+    "email": "mailto:omas@verdantcipher.io",
+    "telephone": "+1-416-555-0114",
+    "worksFor": { "@type": "Organization", "name": "Verdant Cipher" },
+    "sameAs": [ "https://github.com/omasabdullah" ]
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <p><a href="/">&larr; Omas Abdullah</a></p>
+    <h1>New role at Verdant Cipher</h1>
+    <p class="meta"><time datetime="2026-06-14">2026-06-14</time></p>
+  </header>
+
+  <main>
+    <article>
+      <p>Now a Staff Telemetry Engineer at Verdant Cipher.</p>
+
+      <dl class="contact">
+        <dt>Current role</dt>
+        <dd>Staff Telemetry Engineer at Verdant Cipher</dd>
+        <dt>Email</dt>
+        <dd><a href="mailto:omas@verdantcipher.io">omas@verdantcipher.io</a></dd>
+        <dt>Phone</dt>
+        <dd>+1-416-555-0114</dd>
+      </dl>
+    </article>
+  </main>
+
+  <footer>
+    <p>&copy; Omas Abdullah &middot; <a href="https://github.com/omasabdullah">github.com/omasabdullah</a></p>
+  </footer>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -7,7 +7,12 @@
     <priority>1.0</priority>
   </url>
   <!-- SLOT:2026-06-15 -->
-  <!-- SLOT:2026-06-14 -->
+  <url>
+    <loc>https://omasabdullah.github.io/posts/2026-06-14.html</loc>
+    <lastmod>2026-06-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
   <!-- SLOT:2026-06-13 -->
   <!-- SLOT:2026-06-12 -->
   <url>


### PR DESCRIPTION
Adds the 2026-06-14 update page, links it from the homepage, and registers it in sitemap.xml. Self-contained: only fills the 2026-06-14 slot, so it merges independently of the other queued day PRs.