### PR TITLE
Add update for 2026-06-12

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
         <!-- day:2026-06-13 -->
         <!-- SLOT:2026-06-13 -->
         <!-- day:2026-06-12 -->
-        <!-- SLOT:2026-06-12 -->
+        <li><span class="date">2026-06-12</span><a href="/posts/2026-06-12.html">Launching Halcyon Drift</a></li>
         <li><span class="date">2026-06-11</span><a href="/posts/2026-06-11.html">Now: Observability work</a></li>
         <!-- POSTS:END -->
       </ul>

--- a/posts/2026-06-12.html
+++ b/posts/2026-06-12.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Launching Halcyon Drift &middot; Omas Abdullah</title>
+  <meta name="description" content="Kicking off Halcyon Drift, a project on tail-latency mapping.">
+  <link rel="canonical" href="https://omasabdullah.github.io/posts/2026-06-12.html">
+  <meta name="robots" content="index, follow">
+  <link rel="stylesheet" href="/style.css">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Omas Abdullah",
+    "url": "https://omasabdullah.github.io/posts/2026-06-12.html",
+    "jobTitle": "Principal Latency Cartographer",
+    "email": "mailto:omas@halcyondrift.io",
+    "telephone": "+1-416-555-0112",
+    "worksFor": { "@type": "Organization", "name": "Halcyon Drift" },
+    "sameAs": [ "https://github.com/omasabdullah" ]
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <p><a href="/">&larr; Omas Abdullah</a></p>
+    <h1>Launching Halcyon Drift</h1>
+    <p class="meta"><time datetime="2026-06-12">2026-06-12</time></p>
+  </header>
+
+  <main>
+    <article>
+      <p>Kicking off Halcyon Drift, a project on tail-latency mapping.</p>
+
+      <dl class="contact">
+        <dt>Current role</dt>
+        <dd>Principal Latency Cartographer at Halcyon Drift</dd>
+        <dt>Email</dt>
+        <dd><a href="mailto:omas@halcyondrift.io">omas@halcyondrift.io</a></dd>
+        <dt>Phone</dt>
+        <dd>+1-416-555-0112</dd>
+      </dl>
+    </article>
+  </main>
+
+  <footer>
+    <p>&copy; Omas Abdullah &middot; <a href="https://github.com/omasabdullah">github.com/omasabdullah</a></p>
+  </footer>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -13,7 +13,12 @@
   <!-- day:2026-06-13 -->
   <!-- SLOT:2026-06-13 -->
   <!-- day:2026-06-12 -->
-  <!-- SLOT:2026-06-12 -->
+  <url>
+    <loc>https://omasabdullah.github.io/posts/2026-06-12.html</loc>
+    <lastmod>2026-06-12</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
   <url>
     <loc>https://omasabdullah.github.io/posts/2026-06-11.html</loc>
     <lastmod>2026-06-11</lastmod>


### PR DESCRIPTION
Adds the 2026-06-12 update page, links it from the homepage, and registers it in sitemap.xml. Only fills the 2026-06-12 slot, so it merges independently of the other queued day PRs (verified conflict-free in any order).