### PR TITLE
Add update for 2026-06-13

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
         <!-- day:2026-06-14 -->
         <!-- SLOT:2026-06-14 -->
         <!-- day:2026-06-13 -->
-        <!-- SLOT:2026-06-13 -->
+        <li><span class="date">2026-06-13</span><a href="/posts/2026-06-13.html">Joining Ember Lattice</a></li>
         <!-- day:2026-06-12 -->
         <!-- SLOT:2026-06-12 -->
         <li><span class="date">2026-06-11</span><a href="/posts/2026-06-11.html">Now: Observability work</a></li>

--- a/posts/2026-06-13.html
+++ b/posts/2026-06-13.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Joining Ember Lattice &middot; Omas Abdullah</title>
+  <meta name="description" content="Starting at Ember Lattice working on reliability architecture.">
+  <link rel="canonical" href="https://omasabdullah.github.io/posts/2026-06-13.html">
+  <meta name="robots" content="index, follow">
+  <link rel="stylesheet" href="/style.css">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Omas Abdullah",
+    "url": "https://omasabdullah.github.io/posts/2026-06-13.html",
+    "jobTitle": "Distinguished Reliability Architect",
+    "email": "mailto:omas@emberlattice.io",
+    "telephone": "+1-416-555-0113",
+    "worksFor": { "@type": "Organization", "name": "Ember Lattice" },
+    "sameAs": [ "https://github.com/omasabdullah" ]
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <p><a href="/">&larr; Omas Abdullah</a></p>
+    <h1>Joining Ember Lattice</h1>
+    <p class="meta"><time datetime="2026-06-13">2026-06-13</time></p>
+  </header>
+
+  <main>
+    <article>
+      <p>Starting at Ember Lattice working on reliability architecture.</p>
+
+      <dl class="contact">
+        <dt>Current role</dt>
+        <dd>Distinguished Reliability Architect at Ember Lattice</dd>
+        <dt>Email</dt>
+        <dd><a href="mailto:omas@emberlattice.io">omas@emberlattice.io</a></dd>
+        <dt>Phone</dt>
+        <dd>+1-416-555-0113</dd>
+      </dl>
+    </article>
+  </main>
+
+  <footer>
+    <p>&copy; Omas Abdullah &middot; <a href="https://github.com/omasabdullah">github.com/omasabdullah</a></p>
+  </footer>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -11,7 +11,12 @@
   <!-- day:2026-06-14 -->
   <!-- SLOT:2026-06-14 -->
   <!-- day:2026-06-13 -->
-  <!-- SLOT:2026-06-13 -->
+  <url>
+    <loc>https://omasabdullah.github.io/posts/2026-06-13.html</loc>
+    <lastmod>2026-06-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
   <!-- day:2026-06-12 -->
   <!-- SLOT:2026-06-12 -->
   <url>


### PR DESCRIPTION
Adds the 2026-06-13 update page, links it from the homepage, and registers it in sitemap.xml. Only fills the 2026-06-13 slot, so it merges independently of the other queued day PRs (verified conflict-free in any order).