### PR TITLE
Add update for 2026-06-15

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
       <ul id="updates">
         <!-- POSTS:START -->
         <!-- day:2026-06-15 -->
-        <!-- SLOT:2026-06-15 -->
+        <li><span class="date">2026-06-15</span><a href="/posts/2026-06-15.html">Leading data infra at Cobalt Meridian</a></li>
         <!-- day:2026-06-14 -->
         <!-- SLOT:2026-06-14 -->
         <!-- day:2026-06-13 -->

--- a/posts/2026-06-15.html
+++ b/posts/2026-06-15.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Leading data infra at Cobalt Meridian &middot; Omas Abdullah</title>
+  <meta name="description" content="Taking on Head of Data Infrastructure at Cobalt Meridian.">
+  <link rel="canonical" href="https://omasabdullah.github.io/posts/2026-06-15.html">
+  <meta name="robots" content="index, follow">
+  <link rel="stylesheet" href="/style.css">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Omas Abdullah",
+    "url": "https://omasabdullah.github.io/posts/2026-06-15.html",
+    "jobTitle": "Head of Data Infrastructure",
+    "email": "mailto:omas@cobaltmeridian.io",
+    "telephone": "+1-416-555-0115",
+    "worksFor": { "@type": "Organization", "name": "Cobalt Meridian" },
+    "sameAs": [ "https://github.com/omasabdullah" ]
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <p><a href="/">&larr; Omas Abdullah</a></p>
+    <h1>Leading data infra at Cobalt Meridian</h1>
+    <p class="meta"><time datetime="2026-06-15">2026-06-15</time></p>
+  </header>
+
+  <main>
+    <article>
+      <p>Taking on Head of Data Infrastructure at Cobalt Meridian.</p>
+
+      <dl class="contact">
+        <dt>Current role</dt>
+        <dd>Head of Data Infrastructure at Cobalt Meridian</dd>
+        <dt>Email</dt>
+        <dd><a href="mailto:omas@cobaltmeridian.io">omas@cobaltmeridian.io</a></dd>
+        <dt>Phone</dt>
+        <dd>+1-416-555-0115</dd>
+      </dl>
+    </article>
+  </main>
+
+  <footer>
+    <p>&copy; Omas Abdullah &middot; <a href="https://github.com/omasabdullah">github.com/omasabdullah</a></p>
+  </footer>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -7,7 +7,12 @@
     <priority>1.0</priority>
   </url>
   <!-- day:2026-06-15 -->
-  <!-- SLOT:2026-06-15 -->
+  <url>
+    <loc>https://omasabdullah.github.io/posts/2026-06-15.html</loc>
+    <lastmod>2026-06-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
   <!-- day:2026-06-14 -->
   <!-- SLOT:2026-06-14 -->
   <!-- day:2026-06-13 -->


### PR DESCRIPTION
Adds the 2026-06-15 update page, links it from the homepage, and registers it in sitemap.xml. Only fills the 2026-06-15 slot, so it merges independently of the other queued day PRs (verified conflict-free in any order).